### PR TITLE
2023年のデータに対応

### DIFF
--- a/package/app/lib/ui/component/history/result_info_widget.dart
+++ b/package/app/lib/ui/component/history/result_info_widget.dart
@@ -25,7 +25,7 @@ class ResultInfoWidget extends StatelessWidget {
               Text(
                 '${quizResult.unveilPercentage}%'
                 '表示'
-                '（${quizResult.hitterQuiz..unveilCount}/${quizResult.totalStatsCount}）',
+                '（${quizResult.hitterQuiz.unveilCount}/${quizResult.totalStatsCount}）',
               ),
             ],
           ),

--- a/package/app/lib/ui/controller/gallery_list_page_controller.dart
+++ b/package/app/lib/ui/controller/gallery_list_page_controller.dart
@@ -67,9 +67,17 @@ class GalleryListPageController with ControllerMixin {
         .logTapButton('approved_play_past_daily_quiz');
 
     _ref.read(rewardedAdNotifierProvider.notifier).showAd(
-          onUserEarnedReward: () => _ref
-              .read(appRouterProvider)
-              .push(PlayDailyQuizRoute(questionedAt: questionedAt)),
-        );
+      onUserEarnedReward: () async {
+        // dailyQuizResult ドキュメントを保存（新規作成）する。
+        await _ref
+            .read(quizResultServiceProvider)
+            .createDailyQuizResult(questionedAt);
+
+        // プレイ画面へ遷移する。
+        await _ref
+            .read(appRouterProvider)
+            .push(PlayDailyQuizRoute(questionedAt: questionedAt));
+      },
+    );
   }
 }

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.dart
@@ -143,7 +143,11 @@ class PlayDailyQuizPageController extends _$PlayDailyQuizPageController {
 
   Future<List<Hitter>> onSearchHitter(String inputText) async {
     _updateEnteredHitter(null);
-    return ref.read(hitterQuizServiceProvider).searchHitter(inputText);
+
+    final seasonType = state.value!.quizState.hitterQuiz.seasonType;
+    return ref
+        .read(hitterQuizServiceProvider)
+        .searchHitter(inputText, seasonType);
   }
 
   void onSelectedHitter(Hitter value) {

--- a/package/app/lib/ui/controller/play_daily_quiz_page_controller.g.dart
+++ b/package/app/lib/ui/controller/play_daily_quiz_page_controller.g.dart
@@ -7,7 +7,7 @@ part of 'play_daily_quiz_page_controller.dart';
 // **************************************************************************
 
 String _$playDailyQuizPageControllerHash() =>
-    r'8883d6f8091f64ad3e261265dab43c2a70d4fcc8';
+    r'd2556b2781106edee69af260b20821f53aab7b33';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.dart
@@ -127,7 +127,11 @@ class PlayNormalQuizPageController extends _$PlayNormalQuizPageController {
 
   Future<List<Hitter>> onSearchHitter(String inputText) async {
     _updateEnteredHitter(null);
-    return ref.read(hitterQuizServiceProvider).searchHitter(inputText);
+
+    final seasonType = state.value!.normalQuizState.hitterQuiz.seasonType;
+    return ref
+        .read(hitterQuizServiceProvider)
+        .searchHitter(inputText, seasonType);
   }
 
   void onSelectedHitter(Hitter? hitter) {

--- a/package/app/lib/ui/controller/play_normal_quiz_page_controller.g.dart
+++ b/package/app/lib/ui/controller/play_normal_quiz_page_controller.g.dart
@@ -7,7 +7,7 @@ part of 'play_normal_quiz_page_controller.dart';
 // **************************************************************************
 
 String _$playNormalQuizPageControllerHash() =>
-    r'54680be07504fcd158cc4a9f491e08f17ca050ee';
+    r'7a741471aa90b45c925fcea59b0252d1ec56eee3';
 
 /// See also [PlayNormalQuizPageController].
 @ProviderFor(PlayNormalQuizPageController)

--- a/package/app/lib/ui/page/play_daily_quiz_page.dart
+++ b/package/app/lib/ui/page/play_daily_quiz_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -50,8 +51,11 @@ class _PlayDailyQuizPageState extends ConsumerState<PlayDailyQuizPage> {
             child: GestureDetector(
               onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
               behavior: HitTestBehavior.opaque,
-              child: asyncPageState.maybeWhen(
-                orElse: Container.new,
+              child: asyncPageState.when(
+                error: (e, s) {
+                  logger.e('error: $e, stackTrace: $s');
+                  return Container();
+                },
                 loading: () => const Center(child: CircularProgressIndicator()),
                 data: (pageState) {
                   final quizState = pageState.quizState;

--- a/package/model/lib/model.dart
+++ b/package/model/lib/model.dart
@@ -13,4 +13,5 @@ export 'src/feature/push_notification/push_notification.dart';
 export 'src/feature/quiz/quiz.dart';
 export 'src/feature/quiz_result/quiz_result.dart';
 export 'src/feature/search_condition/search_condition.dart';
+export 'src/feature/season/season.dart';
 export 'src/util/util.dart';

--- a/package/model/lib/src/feature/app_info/application/app_info_state.dart
+++ b/package/model/lib/src/feature/app_info/application/app_info_state.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:version/version.dart';
+
+import '../infrastructure/app_info_repository.dart';
+
+part 'app_info_state.g.dart';
+
+/// アプリのアップデートが必要かどうかを返す。
+@riverpod
+Future<bool> needUpdate(NeedUpdateRef ref) async {
+  // アプリのバージョンを取得する。
+  final packageInfo = await PackageInfo.fromPlatform();
+  final userAppVersion = Version.parse(packageInfo.version);
+
+  final appInfoRepository = ref.watch(appInfoRepositoryProvider);
+  late Version requiredAppVersion;
+  if (Platform.isAndroid) {
+    requiredAppVersion =
+        await appInfoRepository.fetchRequiredAppVersionForAndroid();
+  } else {
+    requiredAppVersion =
+        await appInfoRepository.fetchRequiredAppVersionForIos();
+  }
+
+  return userAppVersion < requiredAppVersion;
+}

--- a/package/model/lib/src/feature/app_info/application/app_info_state.g.dart
+++ b/package/model/lib/src/feature/app_info/application/app_info_state.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_info_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$needUpdateHash() => r'144b553d6aa5879d81450e79c0dc7629600bc0e8';
+
+/// アプリのアップデートが必要かどうかを返す。
+///
+/// Copied from [needUpdate].
+@ProviderFor(needUpdate)
+final needUpdateProvider = AutoDisposeFutureProvider<bool>.internal(
+  needUpdate,
+  name: r'needUpdateProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$needUpdateHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef NeedUpdateRef = AutoDisposeFutureProviderRef<bool>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/package/model/lib/src/feature/daily_quiz/domain/daily_quiz.dart
+++ b/package/model/lib/src/feature/daily_quiz/domain/daily_quiz.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../season/util/season_type.dart';
+
 part 'daily_quiz.freezed.dart';
 
 @freezed
@@ -9,5 +11,6 @@ class DailyQuiz with _$DailyQuiz {
     required DateTime questionedAt,
     required String playerId,
     required List<String> selectedStatsList,
+    required SeasonType seasonType,
   }) = _DailyQuiz;
 }

--- a/package/model/lib/src/feature/daily_quiz/domain/daily_quiz.freezed.dart
+++ b/package/model/lib/src/feature/daily_quiz/domain/daily_quiz.freezed.dart
@@ -20,6 +20,7 @@ mixin _$DailyQuiz {
   DateTime get questionedAt => throw _privateConstructorUsedError;
   String get playerId => throw _privateConstructorUsedError;
   List<String> get selectedStatsList => throw _privateConstructorUsedError;
+  SeasonType get seasonType => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $DailyQuizCopyWith<DailyQuiz> get copyWith =>
@@ -35,7 +36,8 @@ abstract class $DailyQuizCopyWith<$Res> {
       {String dailyQuizId,
       DateTime questionedAt,
       String playerId,
-      List<String> selectedStatsList});
+      List<String> selectedStatsList,
+      SeasonType seasonType});
 }
 
 /// @nodoc
@@ -55,6 +57,7 @@ class _$DailyQuizCopyWithImpl<$Res, $Val extends DailyQuiz>
     Object? questionedAt = null,
     Object? playerId = null,
     Object? selectedStatsList = null,
+    Object? seasonType = null,
   }) {
     return _then(_value.copyWith(
       dailyQuizId: null == dailyQuizId
@@ -73,6 +76,10 @@ class _$DailyQuizCopyWithImpl<$Res, $Val extends DailyQuiz>
           ? _value.selectedStatsList
           : selectedStatsList // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      seasonType: null == seasonType
+          ? _value.seasonType
+          : seasonType // ignore: cast_nullable_to_non_nullable
+              as SeasonType,
     ) as $Val);
   }
 }
@@ -89,7 +96,8 @@ abstract class _$$DailyQuizImplCopyWith<$Res>
       {String dailyQuizId,
       DateTime questionedAt,
       String playerId,
-      List<String> selectedStatsList});
+      List<String> selectedStatsList,
+      SeasonType seasonType});
 }
 
 /// @nodoc
@@ -107,6 +115,7 @@ class __$$DailyQuizImplCopyWithImpl<$Res>
     Object? questionedAt = null,
     Object? playerId = null,
     Object? selectedStatsList = null,
+    Object? seasonType = null,
   }) {
     return _then(_$DailyQuizImpl(
       dailyQuizId: null == dailyQuizId
@@ -125,6 +134,10 @@ class __$$DailyQuizImplCopyWithImpl<$Res>
           ? _value._selectedStatsList
           : selectedStatsList // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      seasonType: null == seasonType
+          ? _value.seasonType
+          : seasonType // ignore: cast_nullable_to_non_nullable
+              as SeasonType,
     ));
   }
 }
@@ -136,7 +149,8 @@ class _$DailyQuizImpl implements _DailyQuiz {
       {required this.dailyQuizId,
       required this.questionedAt,
       required this.playerId,
-      required final List<String> selectedStatsList})
+      required final List<String> selectedStatsList,
+      required this.seasonType})
       : _selectedStatsList = selectedStatsList;
 
   @override
@@ -155,8 +169,11 @@ class _$DailyQuizImpl implements _DailyQuiz {
   }
 
   @override
+  final SeasonType seasonType;
+
+  @override
   String toString() {
-    return 'DailyQuiz(dailyQuizId: $dailyQuizId, questionedAt: $questionedAt, playerId: $playerId, selectedStatsList: $selectedStatsList)';
+    return 'DailyQuiz(dailyQuizId: $dailyQuizId, questionedAt: $questionedAt, playerId: $playerId, selectedStatsList: $selectedStatsList, seasonType: $seasonType)';
   }
 
   @override
@@ -171,12 +188,19 @@ class _$DailyQuizImpl implements _DailyQuiz {
             (identical(other.playerId, playerId) ||
                 other.playerId == playerId) &&
             const DeepCollectionEquality()
-                .equals(other._selectedStatsList, _selectedStatsList));
+                .equals(other._selectedStatsList, _selectedStatsList) &&
+            (identical(other.seasonType, seasonType) ||
+                other.seasonType == seasonType));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, dailyQuizId, questionedAt,
-      playerId, const DeepCollectionEquality().hash(_selectedStatsList));
+  int get hashCode => Object.hash(
+      runtimeType,
+      dailyQuizId,
+      questionedAt,
+      playerId,
+      const DeepCollectionEquality().hash(_selectedStatsList),
+      seasonType);
 
   @JsonKey(ignore: true)
   @override
@@ -190,7 +214,8 @@ abstract class _DailyQuiz implements DailyQuiz {
       {required final String dailyQuizId,
       required final DateTime questionedAt,
       required final String playerId,
-      required final List<String> selectedStatsList}) = _$DailyQuizImpl;
+      required final List<String> selectedStatsList,
+      required final SeasonType seasonType}) = _$DailyQuizImpl;
 
   @override
   String get dailyQuizId;
@@ -200,6 +225,8 @@ abstract class _DailyQuiz implements DailyQuiz {
   String get playerId;
   @override
   List<String> get selectedStatsList;
+  @override
+  SeasonType get seasonType;
   @override
   @JsonKey(ignore: true)
   _$$DailyQuizImplCopyWith<_$DailyQuizImpl> get copyWith =>

--- a/package/model/lib/src/feature/daily_quiz/infrastructure/daily_quiz_repository.dart
+++ b/package/model/lib/src/feature/daily_quiz/infrastructure/daily_quiz_repository.dart
@@ -3,6 +3,7 @@ import 'package:common/common.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../season/util/season_type.dart';
 import '../domain/daily_quiz.dart';
 
 part 'daily_quiz_repository.g.dart';
@@ -49,12 +50,15 @@ class DailyQuizRepository {
       final playerId = data['playerId'] as String;
       final selectedStatsList =
           formatSelectedStatsList(data['selectedStatsList'] as List<dynamic>);
+      final seasonType =
+          SeasonType.fromFirestoreValue(data['seasonType'] as String?);
 
       return DailyQuiz(
         dailyQuizId: document.id,
         questionedAt: questionedAt,
         playerId: playerId,
         selectedStatsList: selectedStatsList,
+        seasonType: seasonType,
       );
     }).toList();
 

--- a/package/model/lib/src/feature/quiz/application/answer_state.dart
+++ b/package/model/lib/src/feature/quiz/application/answer_state.dart
@@ -1,5 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../season/util/season_type.dart';
 import '../domain/hitter.dart';
 import '../infrastructure/hitter_repository.dart';
 
@@ -7,5 +8,8 @@ part 'answer_state.g.dart';
 
 /// 全野手のIDと名前のリストを返すプロバイダー
 @riverpod
-Future<List<Hitter>> allHitterList(AllHitterListRef ref) async =>
-    ref.watch(hitterRepositoryProvider).fetchAllHitter();
+Future<List<Hitter>> allHitterList(
+  AllHitterListRef ref,
+  SeasonType seasonType,
+) async =>
+    ref.watch(hitterRepositoryProvider).fetchAllHitter(seasonType);

--- a/package/model/lib/src/feature/quiz/application/answer_state.g.dart
+++ b/package/model/lib/src/feature/quiz/application/answer_state.g.dart
@@ -6,22 +6,166 @@ part of 'answer_state.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$allHitterListHash() => r'f5dbde01e7d38989f618a07f77a2cb57b1fb09df';
+String _$allHitterListHash() => r'ad4f881b0e649af254365072344d103c5a66ead4';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
 
 /// 全野手のIDと名前のリストを返すプロバイダー
 ///
 /// Copied from [allHitterList].
 @ProviderFor(allHitterList)
-final allHitterListProvider = AutoDisposeFutureProvider<List<Hitter>>.internal(
-  allHitterList,
-  name: r'allHitterListProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$allHitterListHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
+const allHitterListProvider = AllHitterListFamily();
 
-typedef AllHitterListRef = AutoDisposeFutureProviderRef<List<Hitter>>;
+/// 全野手のIDと名前のリストを返すプロバイダー
+///
+/// Copied from [allHitterList].
+class AllHitterListFamily extends Family<AsyncValue<List<Hitter>>> {
+  /// 全野手のIDと名前のリストを返すプロバイダー
+  ///
+  /// Copied from [allHitterList].
+  const AllHitterListFamily();
+
+  /// 全野手のIDと名前のリストを返すプロバイダー
+  ///
+  /// Copied from [allHitterList].
+  AllHitterListProvider call(
+    SeasonType seasonType,
+  ) {
+    return AllHitterListProvider(
+      seasonType,
+    );
+  }
+
+  @override
+  AllHitterListProvider getProviderOverride(
+    covariant AllHitterListProvider provider,
+  ) {
+    return call(
+      provider.seasonType,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'allHitterListProvider';
+}
+
+/// 全野手のIDと名前のリストを返すプロバイダー
+///
+/// Copied from [allHitterList].
+class AllHitterListProvider extends AutoDisposeFutureProvider<List<Hitter>> {
+  /// 全野手のIDと名前のリストを返すプロバイダー
+  ///
+  /// Copied from [allHitterList].
+  AllHitterListProvider(
+    SeasonType seasonType,
+  ) : this._internal(
+          (ref) => allHitterList(
+            ref as AllHitterListRef,
+            seasonType,
+          ),
+          from: allHitterListProvider,
+          name: r'allHitterListProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$allHitterListHash,
+          dependencies: AllHitterListFamily._dependencies,
+          allTransitiveDependencies:
+              AllHitterListFamily._allTransitiveDependencies,
+          seasonType: seasonType,
+        );
+
+  AllHitterListProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.seasonType,
+  }) : super.internal();
+
+  final SeasonType seasonType;
+
+  @override
+  Override overrideWith(
+    FutureOr<List<Hitter>> Function(AllHitterListRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: AllHitterListProvider._internal(
+        (ref) => create(ref as AllHitterListRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        seasonType: seasonType,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<List<Hitter>> createElement() {
+    return _AllHitterListProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AllHitterListProvider && other.seasonType == seasonType;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, seasonType.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin AllHitterListRef on AutoDisposeFutureProviderRef<List<Hitter>> {
+  /// The parameter `seasonType` of this provider.
+  SeasonType get seasonType;
+}
+
+class _AllHitterListProviderElement
+    extends AutoDisposeFutureProviderElement<List<Hitter>>
+    with AllHitterListRef {
+  _AllHitterListProviderElement(super.provider);
+
+  @override
+  SeasonType get seasonType => (origin as AllHitterListProvider).seasonType;
+}
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/package/model/lib/src/feature/quiz/application/hitter_quiz_service.dart
+++ b/package/model/lib/src/feature/quiz/application/hitter_quiz_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../season/util/season_type.dart';
 import '../domain/hitter.dart';
 import 'answer_state.dart';
 
@@ -19,8 +20,12 @@ class HitterQuizService {
   final Ref ref;
 
   /// 選手名で検索する
-  Future<List<Hitter>> searchHitter(String searchWord) async {
-    final allHitterList = await ref.read(allHitterListProvider.future);
+  Future<List<Hitter>> searchHitter(
+    String searchWord,
+    SeasonType seasonType,
+  ) async {
+    final allHitterList =
+        await ref.read(allHitterListProvider(seasonType).future);
     final hitterListAfterSearch = <Hitter>[];
 
     for (final hitter in allHitterList) {

--- a/package/model/lib/src/feature/quiz/application/hitter_quiz_state_provider.dart
+++ b/package/model/lib/src/feature/quiz/application/hitter_quiz_state_provider.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../search_condition/application/search_condition_state.dart';
+import '../../season/application/season_state.dart';
 import '../domain/hitter_quiz_state.dart';
 import '../infrastructure/hitter_repository.dart';
 
@@ -12,7 +13,11 @@ part 'hitter_quiz_state_provider.g.dart';
 @riverpod
 Future<HitterQuizState> normalQuizState(NormalQuizStateRef ref) async {
   final searchCondition = ref.watch(searchConditionProvider);
+
+  final now = DateTime.now();
+  final seasonType = await ref.watch(targetSeasonProvider(now).future);
+  
   return ref
       .watch(hitterRepositoryProvider)
-      .fetchNormalHitterQuizState(searchCondition);
+      .fetchNormalHitterQuizState(searchCondition, seasonType);
 }

--- a/package/model/lib/src/feature/quiz/application/hitter_quiz_state_provider.g.dart
+++ b/package/model/lib/src/feature/quiz/application/hitter_quiz_state_provider.g.dart
@@ -6,7 +6,7 @@ part of 'hitter_quiz_state_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$normalQuizStateHash() => r'ffeb9448234053b945629fcff917f96b4d57f45d';
+String _$normalQuizStateHash() => r'c5dec8fbb9e62ecfb91e0ef21ac52417420a43a9';
 
 /// 保存されている検索条件をもとに [HitterQuizState] を取得する。
 ///

--- a/package/model/lib/src/feature/quiz/domain/hitter_quiz.dart
+++ b/package/model/lib/src/feature/quiz/domain/hitter_quiz.dart
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../season/util/season_type.dart';
 import 'stats_value.dart';
 
 part 'hitter_quiz.freezed.dart';
@@ -29,6 +30,9 @@ class HitterQuiz with _$HitterQuiz {
 
     /// 不正解した回数。
     required int incorrectCount,
+
+    /// 対象となるシーズンの種類。
+    required SeasonType seasonType,
   }) = _HitterQuiz;
   const HitterQuiz._();
 

--- a/package/model/lib/src/feature/quiz/domain/hitter_quiz.freezed.dart
+++ b/package/model/lib/src/feature/quiz/domain/hitter_quiz.freezed.dart
@@ -40,6 +40,9 @@ mixin _$HitterQuiz {
   /// 不正解した回数。
   int get incorrectCount => throw _privateConstructorUsedError;
 
+  /// 対象となるシーズンの種類。
+  SeasonType get seasonType => throw _privateConstructorUsedError;
+
   @JsonKey(ignore: true)
   $HitterQuizCopyWith<HitterQuiz> get copyWith =>
       throw _privateConstructorUsedError;
@@ -58,7 +61,8 @@ abstract class $HitterQuizCopyWith<$Res> {
       List<String> selectedStatsList,
       List<Map<String, StatsValue>> statsMapList,
       int unveilCount,
-      int incorrectCount});
+      int incorrectCount,
+      SeasonType seasonType});
 }
 
 /// @nodoc
@@ -81,6 +85,7 @@ class _$HitterQuizCopyWithImpl<$Res, $Val extends HitterQuiz>
     Object? statsMapList = null,
     Object? unveilCount = null,
     Object? incorrectCount = null,
+    Object? seasonType = null,
   }) {
     return _then(_value.copyWith(
       hitterId: null == hitterId
@@ -111,6 +116,10 @@ class _$HitterQuizCopyWithImpl<$Res, $Val extends HitterQuiz>
           ? _value.incorrectCount
           : incorrectCount // ignore: cast_nullable_to_non_nullable
               as int,
+      seasonType: null == seasonType
+          ? _value.seasonType
+          : seasonType // ignore: cast_nullable_to_non_nullable
+              as SeasonType,
     ) as $Val);
   }
 }
@@ -130,7 +139,8 @@ abstract class _$$HitterQuizImplCopyWith<$Res>
       List<String> selectedStatsList,
       List<Map<String, StatsValue>> statsMapList,
       int unveilCount,
-      int incorrectCount});
+      int incorrectCount,
+      SeasonType seasonType});
 }
 
 /// @nodoc
@@ -151,6 +161,7 @@ class __$$HitterQuizImplCopyWithImpl<$Res>
     Object? statsMapList = null,
     Object? unveilCount = null,
     Object? incorrectCount = null,
+    Object? seasonType = null,
   }) {
     return _then(_$HitterQuizImpl(
       hitterId: null == hitterId
@@ -181,6 +192,10 @@ class __$$HitterQuizImplCopyWithImpl<$Res>
           ? _value.incorrectCount
           : incorrectCount // ignore: cast_nullable_to_non_nullable
               as int,
+      seasonType: null == seasonType
+          ? _value.seasonType
+          : seasonType // ignore: cast_nullable_to_non_nullable
+              as SeasonType,
     ));
   }
 }
@@ -195,7 +210,8 @@ class _$HitterQuizImpl extends _HitterQuiz {
       required final List<String> selectedStatsList,
       required final List<Map<String, StatsValue>> statsMapList,
       required this.unveilCount,
-      required this.incorrectCount})
+      required this.incorrectCount,
+      required this.seasonType})
       : _yearList = yearList,
         _selectedStatsList = selectedStatsList,
         _statsMapList = statsMapList,
@@ -255,9 +271,13 @@ class _$HitterQuizImpl extends _HitterQuiz {
   @override
   final int incorrectCount;
 
+  /// 対象となるシーズンの種類。
+  @override
+  final SeasonType seasonType;
+
   @override
   String toString() {
-    return 'HitterQuiz(hitterId: $hitterId, hitterName: $hitterName, yearList: $yearList, selectedStatsList: $selectedStatsList, statsMapList: $statsMapList, unveilCount: $unveilCount, incorrectCount: $incorrectCount)';
+    return 'HitterQuiz(hitterId: $hitterId, hitterName: $hitterName, yearList: $yearList, selectedStatsList: $selectedStatsList, statsMapList: $statsMapList, unveilCount: $unveilCount, incorrectCount: $incorrectCount, seasonType: $seasonType)';
   }
 
   @override
@@ -277,7 +297,9 @@ class _$HitterQuizImpl extends _HitterQuiz {
             (identical(other.unveilCount, unveilCount) ||
                 other.unveilCount == unveilCount) &&
             (identical(other.incorrectCount, incorrectCount) ||
-                other.incorrectCount == incorrectCount));
+                other.incorrectCount == incorrectCount) &&
+            (identical(other.seasonType, seasonType) ||
+                other.seasonType == seasonType));
   }
 
   @override
@@ -289,7 +311,8 @@ class _$HitterQuizImpl extends _HitterQuiz {
       const DeepCollectionEquality().hash(_selectedStatsList),
       const DeepCollectionEquality().hash(_statsMapList),
       unveilCount,
-      incorrectCount);
+      incorrectCount,
+      seasonType);
 
   @JsonKey(ignore: true)
   @override
@@ -306,7 +329,8 @@ abstract class _HitterQuiz extends HitterQuiz {
       required final List<String> selectedStatsList,
       required final List<Map<String, StatsValue>> statsMapList,
       required final int unveilCount,
-      required final int incorrectCount}) = _$HitterQuizImpl;
+      required final int incorrectCount,
+      required final SeasonType seasonType}) = _$HitterQuizImpl;
   const _HitterQuiz._() : super._();
 
   @override
@@ -339,6 +363,10 @@ abstract class _HitterQuiz extends HitterQuiz {
 
   /// 不正解した回数。
   int get incorrectCount;
+  @override
+
+  /// 対象となるシーズンの種類。
+  SeasonType get seasonType;
   @override
   @JsonKey(ignore: true)
   _$$HitterQuizImplCopyWith<_$HitterQuizImpl> get copyWith =>

--- a/package/model/lib/src/feature/quiz/infrastructure/hitter_converter.dart
+++ b/package/model/lib/src/feature/quiz/infrastructure/hitter_converter.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 
 import '../../../util/enum/hitting_stats_type.dart';
+import '../../season/util/season_type.dart';
 import '../domain/hitter_quiz.dart';
 import '../domain/hitter_quiz_state.dart';
 import '../domain/stats_value.dart';
@@ -15,11 +16,13 @@ class HitterConverter {
     SupabaseHitter supabaseHitter,
     List<HittingStats> rowStatsList,
     List<String> selectedStatsList,
+    SeasonType seasonType,
   ) {
     final hitterQuiz = _createHitterQuiz(
       supabaseHitter,
       rowStatsList,
       selectedStatsList,
+      seasonType,
     );
 
     return HitterQuizState.normal(
@@ -33,11 +36,13 @@ class HitterConverter {
     SupabaseHitter supabaseHitter,
     List<HittingStats> rowStatsList,
     List<String> selectedStatsList,
+    SeasonType seasonType,
   ) {
     final hitterQuiz = _createHitterQuiz(
       supabaseHitter,
       rowStatsList,
       selectedStatsList,
+      seasonType,
     );
 
     return HitterQuizState.daily(
@@ -83,6 +88,7 @@ class HitterConverter {
     SupabaseHitter supabaseHitter,
     List<HittingStats> rowStatsList,
     List<String> selectedStatsList,
+    SeasonType seasonType,
   ) {
     final statsListForUi =
         _createStatsListForUi(rowStatsList, selectedStatsList);
@@ -96,6 +102,7 @@ class HitterConverter {
       statsMapList: statsListForUi,
       unveilCount: 0,
       incorrectCount: 0,
+      seasonType: seasonType,
     );
   }
 

--- a/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.dart
+++ b/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.dart
@@ -6,6 +6,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../daily_quiz/domain/daily_quiz.dart';
 import '../../search_condition/domain/search_condition.dart';
+import '../../season/util/season_type.dart';
 import '../domain/hitter.dart';
 import '../domain/hitter_quiz_state.dart';
 import 'entity/hitting_stats.dart';
@@ -30,19 +31,21 @@ class HitterRepository {
   /// 検索条件に合う選手を1人取得し、その選手の成績を取得して返す。
   Future<HitterQuizState> fetchNormalHitterQuizState(
     SearchCondition searchCondition,
+    SeasonType seasonType,
   ) async {
     // 検索条件に合う選手を1人取得する。
     final supabaseHitter =
-        await _searchHitterBySearchCondition(searchCondition);
+        await _searchHitterBySearchCondition(searchCondition, seasonType);
 
     // 取得した選手の成績を取得する。
-    final statsList = await _fetchHittingStats(supabaseHitter.id);
+    final statsList = await _fetchHittingStats(supabaseHitter.id, seasonType);
 
     // InputNormalQuizState に変換して返す。
     return HitterConverter().toInputNormalQuizState(
       supabaseHitter,
       statsList,
       searchCondition.selectedStatsList,
+      seasonType,
     );
   }
 
@@ -50,34 +53,40 @@ class HitterRepository {
   ///
   /// 指定されたデイリークイズの選手 ID から選手情報を取得し、その選手の成績を取得して返す。
   Future<HitterQuizState> fetchInputDailyQuizState(DailyQuiz dailyQuiz) async {
+    final seasonType = dailyQuiz.seasonType;
+
     // 検索条件に合う選手を1人取得する。
-    final supabaseHitter = await _searchHitterById(dailyQuiz.playerId);
+    final supabaseHitter =
+        await _searchHitterById(dailyQuiz.playerId, seasonType);
 
     // 取得した選手の成績を取得する。
-    final statsList = await _fetchHittingStats(supabaseHitter.id);
+    final statsList = await _fetchHittingStats(supabaseHitter.id, seasonType);
 
     // InputDailyQuizState に変換して返す。
     return HitterConverter().toInputDailyQuizState(
       supabaseHitter,
       statsList,
       dailyQuiz.selectedStatsList,
+      seasonType,
     );
   }
 
   /// 検索条件で選手で検索し、ランダムで1人返す。
   Future<SupabaseHitter> _searchHitterBySearchCondition(
     SearchCondition searchCondition,
+    SeasonType seasonType,
   ) async {
+    final hittingStatsTable = seasonType.hittingStatsTable;
     final responses = await supabase.client
-        .from('hitter_table')
+        .from(seasonType.hitterTable)
         .select<dynamic>(
-          'id, name, team, hasData, hitting_stats_table!inner(*)',
+          'id, name, team, hasData, $hittingStatsTable!inner(*)',
         )
         .eq('hasData', true)
         .filter('team', 'in', searchCondition.teamList)
-        .gte('hitting_stats_table.試合', searchCondition.minGames)
-        .gte('hitting_stats_table.安打', searchCondition.minHits)
-        .gte('hitting_stats_table.本塁打', searchCondition.minHr) as List<dynamic>;
+        .gte('$hittingStatsTable.試合', searchCondition.minGames)
+        .gte('$hittingStatsTable.安打', searchCondition.minHits)
+        .gte('$hittingStatsTable.本塁打', searchCondition.minHr) as List<dynamic>;
 
     // 検索条件に合致する選手がいない場合、例外を返す。
     if (responses.isEmpty) {
@@ -92,9 +101,12 @@ class HitterRepository {
   }
 
   /// ID で選手を検索する。
-  Future<SupabaseHitter> _searchHitterById(String id) async {
+  Future<SupabaseHitter> _searchHitterById(
+    String id,
+    SeasonType seasonType,
+  ) async {
     final responses = await supabase.client
-        .from('hitter_table')
+        .from(seasonType.hitterTable)
         .select<dynamic>(
           'id, name, team, hasData',
         )
@@ -110,10 +122,13 @@ class HitterRepository {
   }
 
   /// [playerId] から打撃成績の List を取得するする。
-  Future<List<HittingStats>> _fetchHittingStats(String playerId) async {
+  Future<List<HittingStats>> _fetchHittingStats(
+    String playerId,
+    SeasonType seasonType,
+  ) async {
     final statsList = <HittingStats>[];
     final responses = await supabase.client
-        .from('hitting_stats_table')
+        .from(seasonType.hittingStatsTable)
         .select<dynamic>()
         .eq('playerId', playerId) as List<dynamic>;
 
@@ -128,9 +143,9 @@ class HitterRepository {
   /// 解答を入力するテキストフィールドの検索用。
   ///
   /// 全選手の名前と ID を取得する。
-  Future<List<Hitter>> fetchAllHitter() async {
+  Future<List<Hitter>> fetchAllHitter(SeasonType seasonType) async {
     final responses = await supabase.client
-        .from('hitter_table')
+        .from(seasonType.hitterTable)
         .select<dynamic>() as List<dynamic>;
 
     final allHitterList = <Hitter>[];

--- a/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.dart
+++ b/package/model/lib/src/feature/quiz/infrastructure/hitter_repository.dart
@@ -79,14 +79,15 @@ class HitterRepository {
     final hittingStatsTable = seasonType.hittingStatsTable;
     final responses = await supabase.client
         .from(seasonType.hitterTable)
-        .select<dynamic>(
-          'id, name, team, hasData, $hittingStatsTable!inner(*)',
-        )
+        .select<dynamic>('id, name, team, hasData, $hittingStatsTable!inner(*)')
         .eq('hasData', true)
         .filter('team', 'in', searchCondition.teamList)
         .gte('$hittingStatsTable.試合', searchCondition.minGames)
         .gte('$hittingStatsTable.安打', searchCondition.minHits)
-        .gte('$hittingStatsTable.本塁打', searchCondition.minHr) as List<dynamic>;
+        .gte('$hittingStatsTable.本塁打', searchCondition.minHr)
+        // ? なぜか `ascending` は true でも false でも同じ結果になる。
+        // ? UI での挙動的には問題ないので、このままにしておいている。
+        .order('表示順', foreignTable: hittingStatsTable) as List<dynamic>;
 
     // 検索条件に合致する選手がいない場合、例外を返す。
     if (responses.isEmpty) {

--- a/package/model/lib/src/feature/quiz_result/infrastructure/quiz_result_repository.dart
+++ b/package/model/lib/src/feature/quiz_result/infrastructure/quiz_result_repository.dart
@@ -9,6 +9,7 @@ import '../../quiz/domain/hitter_quiz.dart';
 import '../../quiz/domain/hitter_quiz_state.dart';
 import '../../quiz/domain/stats_value.dart';
 import '../../search_condition/domain/search_condition.dart';
+import '../../season/util/season_type.dart';
 import '../domain/daily_hitter_quiz_result.dart';
 import '../domain/hitter_quiz_result.dart';
 
@@ -194,6 +195,7 @@ class QuizResultRepository {
           .toList(),
       unveilCount: data['unveilCount'] as int,
       incorrectCount: data['incorrectCount'] as int,
+      seasonType: SeasonType.fromFirestoreValue(data['seasonType'] as String?),
     );
   }
 

--- a/package/model/lib/src/feature/quiz_result/infrastructure/quiz_result_repository.dart
+++ b/package/model/lib/src/feature/quiz_result/infrastructure/quiz_result_repository.dart
@@ -35,6 +35,7 @@ class QuizResultRepository {
         .set(<String, dynamic>{
       'createdAt': FieldValue.serverTimestamp(),
       'updatedAt': FieldValue.serverTimestamp(),
+      'targetSeasonType': dailyQuiz.seasonType.firestoreValue,
     });
   }
 
@@ -72,6 +73,7 @@ class QuizResultRepository {
       'unveilCount': hitterQuiz.unveilCount,
       'isCorrect': quizState.isCorrectEnteredHitter,
       'incorrectCount': hitterQuiz.incorrectCount,
+      'targetSeasonType': dailyQuiz.seasonType.firestoreValue,
     });
   }
 
@@ -109,6 +111,7 @@ class QuizResultRepository {
       'isCorrect': quizState.isCorrectEnteredHitter,
       'incorrectCount': hitterQuiz.incorrectCount,
       'searchCondition': searchCondition.toJson(),
+      'targetSeasonType': hitterQuiz.seasonType.firestoreValue,
     });
   }
 
@@ -238,11 +241,12 @@ class QuizResultRepository {
     return snapshot.count!;
   }
 
-  Future<void> deleteNormalQuizResult(User user, String docId) async =>
-      firestore
-          .collection('users')
-          .doc(user.uid)
-          .collection('normalQuizResult')
-          .doc(docId)
-          .delete();
+  Future<void> deleteNormalQuizResult(User user, String docId) async {
+    return firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('normalQuizResult')
+        .doc(docId)
+        .delete();
+  }
 }

--- a/package/model/lib/src/feature/season/application/season_state.dart
+++ b/package/model/lib/src/feature/season/application/season_state.dart
@@ -1,0 +1,11 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../infrastructure/season_repository.dart';
+import '../util/season_type.dart';
+
+part 'season_state.g.dart';
+
+@riverpod
+Future<SeasonType> targetSeason(TargetSeasonRef ref, DateTime baseDate) async {
+  return ref.watch(seasonRepositoryProvider).fetchTargetSeason(baseDate);
+}

--- a/package/model/lib/src/feature/season/application/season_state.g.dart
+++ b/package/model/lib/src/feature/season/application/season_state.g.dart
@@ -1,0 +1,158 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'season_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$targetSeasonHash() => r'f3b18745366e6ac13106b1fe8aad4434b6fb48b0';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [targetSeason].
+@ProviderFor(targetSeason)
+const targetSeasonProvider = TargetSeasonFamily();
+
+/// See also [targetSeason].
+class TargetSeasonFamily extends Family<AsyncValue<SeasonType>> {
+  /// See also [targetSeason].
+  const TargetSeasonFamily();
+
+  /// See also [targetSeason].
+  TargetSeasonProvider call(
+    DateTime baseDate,
+  ) {
+    return TargetSeasonProvider(
+      baseDate,
+    );
+  }
+
+  @override
+  TargetSeasonProvider getProviderOverride(
+    covariant TargetSeasonProvider provider,
+  ) {
+    return call(
+      provider.baseDate,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'targetSeasonProvider';
+}
+
+/// See also [targetSeason].
+class TargetSeasonProvider extends AutoDisposeFutureProvider<SeasonType> {
+  /// See also [targetSeason].
+  TargetSeasonProvider(
+    DateTime baseDate,
+  ) : this._internal(
+          (ref) => targetSeason(
+            ref as TargetSeasonRef,
+            baseDate,
+          ),
+          from: targetSeasonProvider,
+          name: r'targetSeasonProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$targetSeasonHash,
+          dependencies: TargetSeasonFamily._dependencies,
+          allTransitiveDependencies:
+              TargetSeasonFamily._allTransitiveDependencies,
+          baseDate: baseDate,
+        );
+
+  TargetSeasonProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.baseDate,
+  }) : super.internal();
+
+  final DateTime baseDate;
+
+  @override
+  Override overrideWith(
+    FutureOr<SeasonType> Function(TargetSeasonRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: TargetSeasonProvider._internal(
+        (ref) => create(ref as TargetSeasonRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        baseDate: baseDate,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<SeasonType> createElement() {
+    return _TargetSeasonProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is TargetSeasonProvider && other.baseDate == baseDate;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, baseDate.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin TargetSeasonRef on AutoDisposeFutureProviderRef<SeasonType> {
+  /// The parameter `baseDate` of this provider.
+  DateTime get baseDate;
+}
+
+class _TargetSeasonProviderElement
+    extends AutoDisposeFutureProviderElement<SeasonType> with TargetSeasonRef {
+  _TargetSeasonProviderElement(super.provider);
+
+  @override
+  DateTime get baseDate => (origin as TargetSeasonProvider).baseDate;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/package/model/lib/src/feature/season/infrastructure/season_repository.dart
+++ b/package/model/lib/src/feature/season/infrastructure/season_repository.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:common/common.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../util/season_type.dart';
@@ -5,13 +7,31 @@ import '../util/season_type.dart';
 part 'season_repository.g.dart';
 
 @riverpod
-SeasonRepository seasonRepository(SeasonRepositoryRef ref) =>
-    SeasonRepository();
+SeasonRepository seasonRepository(SeasonRepositoryRef ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return SeasonRepository(firestore);
+}
 
 class SeasonRepository {
+  SeasonRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
   /// [baseDate]を基準として、対象となるシーズンを取得する。
   Future<SeasonType> fetchTargetSeason(DateTime baseDate) async {
-    // todo: 実装する。
-    return SeasonType.end2022;
+    final QuerySnapshot querySnapshot = await _firestore
+        .collection('seasonPeriods')
+        .where('startDate', isLessThanOrEqualTo: baseDate)
+        .orderBy('startDate', descending: true)
+        .limit(1)
+        .get();
+
+    if (querySnapshot.docs.isEmpty) {
+      // * 対象ドキュメントが見つからなかった場合
+      throw FistoreException.notFound();
+    }
+    // * 対象ドキュメントが見つかった場合
+    final DocumentSnapshot document = querySnapshot.docs.first;
+    return SeasonType.fromFirestoreValue(document['seasonType'] as String);
   }
 }

--- a/package/model/lib/src/feature/season/infrastructure/season_repository.dart
+++ b/package/model/lib/src/feature/season/infrastructure/season_repository.dart
@@ -1,0 +1,17 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../util/season_type.dart';
+
+part 'season_repository.g.dart';
+
+@riverpod
+SeasonRepository seasonRepository(SeasonRepositoryRef ref) =>
+    SeasonRepository();
+
+class SeasonRepository {
+  /// [baseDate]を基準として、対象となるシーズンを取得する。
+  Future<SeasonType> fetchTargetSeason(DateTime baseDate) async {
+    // todo: 実装する。
+    return SeasonType.end2022;
+  }
+}

--- a/package/model/lib/src/feature/season/infrastructure/season_repository.g.dart
+++ b/package/model/lib/src/feature/season/infrastructure/season_repository.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'season_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$seasonRepositoryHash() => r'f95e26403e0641652f744082403959000298adae';
+
+/// See also [seasonRepository].
+@ProviderFor(seasonRepository)
+final seasonRepositoryProvider = AutoDisposeProvider<SeasonRepository>.internal(
+  seasonRepository,
+  name: r'seasonRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$seasonRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef SeasonRepositoryRef = AutoDisposeProviderRef<SeasonRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/package/model/lib/src/feature/season/season.dart
+++ b/package/model/lib/src/feature/season/season.dart
@@ -1,0 +1,3 @@
+export 'application/season_state.dart';
+export 'infrastructure/season_repository.dart';
+export 'util/season_type.dart';

--- a/package/model/lib/src/feature/season/util/season_type.dart
+++ b/package/model/lib/src/feature/season/util/season_type.dart
@@ -1,0 +1,65 @@
+/// どの時点で取得したデータかを判別するための enum.
+enum SeasonType {
+  /// 2022年シーズン終了時。
+  ///
+  /// 厳密には、 2022-12-04 時点。
+  end2022,
+
+  /// 2023年シーズン終了時。
+  ///
+  /// 厳密には、 2024-01-10 時点。
+  end2023;
+
+  static const _end2022 = 'end2022';
+  static const _end2023 = 'end2023';
+
+  /// Firestore に保存する値。
+  String get firestoreValue {
+    switch (this) {
+      case SeasonType.end2022:
+        return _end2022;
+      case SeasonType.end2023:
+        return _end2023;
+    }
+  }
+
+  /// Firestore から取得した値を enum に変換する。
+  static SeasonType fromFirestoreValue(String? value) {
+    // value が null の場合は、 `QuizSeasonType.end2022` とする。
+    //
+    // ※ `QuizSeasonType.firestoreValue` を保持するフィールドを作成したのは、
+    // `QuizSeasonType.end2023` 実装時であるため。
+    if (value == null) {
+      return SeasonType.end2022;
+    }
+
+    switch (value) {
+      case _end2022:
+        return SeasonType.end2022;
+      case _end2023:
+        return SeasonType.end2023;
+      default:
+        throw ArgumentError('不正な値です: $value');
+    }
+  }
+
+  /// 野手の基本情報を格納するテーブルの名称。
+  String get hitterTable {
+    switch (this) {
+      case SeasonType.end2022:
+        return 'hitter_table';
+      case SeasonType.end2023:
+        return 'hitter_table_20240110';
+    }
+  }
+
+  /// 野手の成績を格納するテーブルの名称。
+  String get hittingStatsTable {
+    switch (this) {
+      case SeasonType.end2022:
+        return 'hitting_stats_table';
+      case SeasonType.end2023:
+        return 'hitting_stats_table_20240110';
+    }
+  }
+}

--- a/package/model/test/dummy_data/dummy_hitter.dart
+++ b/package/model/test/dummy_data/dummy_hitter.dart
@@ -3,6 +3,7 @@ import 'package:model/src/feature/quiz/domain/stats_value.dart';
 import 'package:model/src/feature/quiz/infrastructure/entity/hitting_stats.dart';
 import 'package:model/src/feature/quiz/infrastructure/entity/supabase_hitter.dart';
 import 'package:model/src/feature/search_condition/domain/search_condition.dart';
+import 'package:model/src/feature/season/util/season_type.dart';
 
 const dummyHitter = SupabaseHitter(
   id: '9d377b08-3b1d-4ff2-892f-597c404e4b7d',
@@ -170,4 +171,5 @@ const dummyHitterQuiz = HitterQuiz(
   ],
   unveilCount: 0,
   incorrectCount: 0,
+  seasonType: SeasonType.end2022,
 );

--- a/package/model/test/dummy_data/dummy_hitter_quiz_result.dart
+++ b/package/model/test/dummy_data/dummy_hitter_quiz_result.dart
@@ -1,6 +1,7 @@
 import 'package:model/src/feature/quiz/domain/hitter_quiz.dart';
 import 'package:model/src/feature/quiz/domain/stats_value.dart';
 import 'package:model/src/feature/quiz_result/domain/hitter_quiz_result.dart';
+import 'package:model/src/feature/season/util/season_type.dart';
 
 const dummyHitterQuiz = HitterQuiz(
   hitterId: 'dummyHitterId',
@@ -41,6 +42,7 @@ const dummyHitterQuiz = HitterQuiz(
   ],
   unveilCount: 0,
   incorrectCount: 0,
+  seasonType: SeasonType.end2022,
 );
 
 final dummyHitterQuizResult = HitterQuizResult(

--- a/package/model/test/feature/quiz/application/hitter_quiz_service_test.dart
+++ b/package/model/test/feature/quiz/application/hitter_quiz_service_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:model/src/feature/quiz/application/answer_state.dart';
 import 'package:model/src/feature/quiz/application/hitter_quiz_service.dart';
 import 'package:model/src/feature/quiz/domain/hitter.dart';
+import 'package:model/src/feature/season/util/season_type.dart';
 
 void main() {
   group('filterHitter関数', () {
@@ -16,7 +17,7 @@ void main() {
     test('5文字（カタカナ）, 1選手に該当', () async {
       final container = ProviderContainer(
         overrides: [
-          allHitterListProvider.overrideWith(
+          allHitterListProvider(SeasonType.end2022).overrideWith(
             (ref) => Future.value(hitterList),
           ),
         ],
@@ -24,7 +25,7 @@ void main() {
       const searchWord = 'マーティン';
       final result = await container
           .read(hitterQuizServiceProvider)
-          .searchHitter(searchWord);
+          .searchHitter(searchWord, SeasonType.end2022);
 
       final expected = [
         const Hitter(label: 'レオネス・マーティン', id: '3'),
@@ -36,7 +37,7 @@ void main() {
     test('2文字（漢字）, 2選手に該当', () async {
       final container = ProviderContainer(
         overrides: [
-          allHitterListProvider.overrideWith(
+          allHitterListProvider(SeasonType.end2022).overrideWith(
             (ref) => Future.value(hitterList),
           ),
         ],
@@ -44,7 +45,7 @@ void main() {
       const searchWord = '坂本';
       final result = await container
           .read(hitterQuizServiceProvider)
-          .searchHitter(searchWord);
+          .searchHitter(searchWord, SeasonType.end2022);
 
       final expected = [
         const Hitter(label: '坂本勇人（捕手）', id: '1'),
@@ -57,7 +58,7 @@ void main() {
     test('1文字（アルファベット）, 1選手に該当', () async {
       final container = ProviderContainer(
         overrides: [
-          allHitterListProvider.overrideWith(
+          allHitterListProvider(SeasonType.end2022).overrideWith(
             (ref) => Future.value(hitterList),
           ),
         ],
@@ -65,7 +66,7 @@ void main() {
       const searchWord = 'T';
       final result = await container
           .read(hitterQuizServiceProvider)
-          .searchHitter(searchWord);
+          .searchHitter(searchWord, SeasonType.end2022);
 
       final expected = [
         const Hitter(label: 'T-岡田', id: '4'),
@@ -77,7 +78,7 @@ void main() {
     test('1文字（漢字）, 該当選手なし', () async {
       final container = ProviderContainer(
         overrides: [
-          allHitterListProvider.overrideWith(
+          allHitterListProvider(SeasonType.end2022).overrideWith(
             (ref) => Future.value(hitterList),
           ),
         ],
@@ -85,7 +86,7 @@ void main() {
       const searchWord = '神';
       final result = await container
           .read(hitterQuizServiceProvider)
-          .searchHitter(searchWord);
+          .searchHitter(searchWord, SeasonType.end2022);
 
       final expected = <Hitter>[];
 

--- a/package/model/test/feature/quiz/infrastructure/supabase/supabase_hitter_converter_test.dart
+++ b/package/model/test/feature/quiz/infrastructure/supabase/supabase_hitter_converter_test.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:model/src/feature/quiz/infrastructure/hitter_converter.dart';
+import 'package:model/src/feature/season/util/season_type.dart';
 import 'package:model/src/util/enum/hitting_stats_type.dart';
 
 import '../../../../dummy_data/dummy_hitter.dart';
@@ -15,6 +16,7 @@ void main() async {
             dummyHitter,
             dummyHittingStatsList,
             dummySearchCondition.selectedStatsList,
+            SeasonType.end2022,
           )
           .hitterQuiz;
 


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #284 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- 状況において2023年シーズン終了時点のデータを取得するよう更新

## やらなかったこと

- 

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

## 動作確認

### 確認した環境

- Pixel 6a (実機) / Android 15

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- ざっくり問題なく動作すること

### 確認しなかった（できなかった）こと

- 細かい部分の確認

## その他
