### PR TITLE
Android のアラーム権限エラーを解消

### DIFF
--- a/package/app/android/app/src/main/AndroidManifest.xml
+++ b/package/app/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.toda.baseball_quiz_app">
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <queries>
     <!-- If your app opens https URLs -->
         <intent>

--- a/package/model/lib/src/feature/push_notification/application/local_push_notification_service.dart
+++ b/package/model/lib/src/feature/push_notification/application/local_push_notification_service.dart
@@ -113,6 +113,7 @@ class LocalPushNotificationService {
       matchDateTimeComponents: DateTimeComponents.time,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
     );
   }
 
@@ -152,6 +153,7 @@ class LocalPushNotificationService {
       matchDateTimeComponents: DateTimeComponents.time,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
     );
   }
 
@@ -192,6 +194,7 @@ class LocalPushNotificationService {
       matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
     );
   }
 


### PR DESCRIPTION
## 対応する Issue

<!-- 該当の Issue を Close したくない場合は、 `Closes` の文言を削除する。 -->
Closes #329 

## リンク

<!-- タスク管理/整理用の Notion ページや参考にしたサイト等があれば記載する。 -->

## やったこと

- ローカル PUSH 通知で、正確なアラームではなく不正確なアラームを設定するよう修正

参考
https://zenn.dev/koji_1009/articles/28ddc9ec95d803#%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%82%84%E3%82%A2%E3%83%A9%E3%83%BC%E3%83%A0%E3%82%A2%E3%83%97%E3%83%AA%E3%81%A7%E3%81%AF%E3%81%AA%E3%81%84%E3%82%A2%E3%83%97%E3%83%AA

## やらなかったこと

## ユーザーへの影響

<!-- ユーザーから見て、できるようになったことやできなくなったこと等を記載する。 -->

- ローカル PUSH 通知が送られる時間が曖昧になる？（未検証、未調査）

## 動作確認

### 確認した環境

- Pixel 6a (実機) / Android 14

### 確認したこと
<!-- スクショや動画を貼っても良い。 -->

- ビルド時、今日の1問プレイ時にエラーが出ないことを確認

### 確認しなかった（できなかった）こと

- 

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリが正確なアラームをスケジュールするための新しい権限を追加しました。
  - ローカルプッシュ通知のスケジューリング機能が改善され、バッテリー使用を最適化しながら通知がタイムリーに配信されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->